### PR TITLE
Added magnet command, support for 8 different magnet drives

### DIFF
--- a/dyno/microcontroller/Session.h
+++ b/dyno/microcontroller/Session.h
@@ -9,7 +9,7 @@
 class Session {
    public:
        //interface
-       Session(const int POT_PIN, const int DRV_PIN, bool paused);
+       Session(const int POT_PIN, const int* DRV_PIN, bool paused, bool drive_w_pot=false);
        void init_temp_sense(const int *TEMP_PINS);
        void check_for_command();
        bool check_paused();
@@ -26,11 +26,12 @@ class Session {
        int m_pot_pin;       
        int m_temp_pins[NUM_TEMP_SENSE];
        float m_temps[NUM_TEMP_SENSE];
-       int m_drv_pin;
-       int m_pwm;
-       char com_buff[256];
-       int com_buff_count;
+       int m_drv_pins[8];
+       int m_pwms[NUM_MAGNETS];
+       char m_com_buff[256];
+       int m_com_buff_count;
        bool m_paused_flag;
+       bool m_drive_w_pot;
 };
 
 #endif

--- a/dyno/microcontroller/constants.h
+++ b/dyno/microcontroller/constants.h
@@ -5,6 +5,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
+// Constants for dyno
 const int POT_PIN = A0;
 const int NUM_TEMP_SENSE = 5;
 const int TEMP_PINS[NUM_TEMP_SENSE] = {A1, A2, A3, A4, A5}; //Use TMP36 sensors

--- a/dyno/microcontroller/constants.h
+++ b/dyno/microcontroller/constants.h
@@ -8,7 +8,8 @@
 const int POT_PIN = A0;
 const int NUM_TEMP_SENSE = 5;
 const int TEMP_PINS[NUM_TEMP_SENSE] = {A1, A2, A3, A4, A5}; //Use TMP36 sensors
-const int DRV_PIN = 5;
+const int NUM_MAGNETS = 8;
+const int DRV_PINS[8] = {5, 6, 7, 8, 9, 10, 11, 12};
 const int POT_LOWER = 0;
 const int POT_UPPER = 1023;
 const int REPORT_PERIOD = 500; //in ms

--- a/dyno/microcontroller/microcontroller.ino
+++ b/dyno/microcontroller/microcontroller.ino
@@ -8,7 +8,7 @@ int end_time;                          //
 
 void setup() {
   Serial.begin(9600);
-  sesh = new Session(POT_PIN, DRV_PIN, false);
+  sesh = new Session(POT_PIN, DRV_PINS, false);
   sesh->init_temp_sense(TEMP_PINS); //configure in constants.h
   end_time = 0; //report timer
 }


### PR DESCRIPTION
### Summary
Added support for a magnet command from the LP to set the PWM of any of the 8 magnets. The expected format of the command is as follows:
`MAGNET=1:200;4:001;`

Main things to note about the expected format:
1. Expects magnet ID's between 0 and 7, _**NOT**_ 1 and 8
2. Expects the PWM value to be 3 characters long, even if it requires fewer digits. e.g. 002, **_NOT_** 2
3. You do not need to pass every magnet to the magnet command. Only pass the ones that need a PWM change.

### Test Plan
- [x] Compiles
- [ ] Tested offline with serial prints
- [ ] Tested online with Dyno 