### PR TITLE
[dyno] Added ACK response and serial stats struct for debugging

### DIFF
--- a/dyno/microcontroller/Session.h
+++ b/dyno/microcontroller/Session.h
@@ -6,32 +6,43 @@
 #define SESH_H
 #include "constants.h"
 
-class Session {
-   public:
-       //interface
-       Session(const int POT_PIN, const int* DRV_PIN, bool paused, bool drive_w_pot=false);
-       void init_temp_sense(const int *TEMP_PINS);
-       void check_for_command();
-       bool check_paused();
-       void read_pot();
-       void read_temp();
-       void drive_magnet();
-       void print_report();
-   private:
-       //private functions
-       void process_command();
-       int ramp_signal(int sig_in);
-      
-       //data members
-       int m_pot_pin;       
-       int m_temp_pins[NUM_TEMP_SENSE];
-       float m_temps[NUM_TEMP_SENSE];
-       int m_drv_pins[8];
-       int m_pwms[NUM_MAGNETS];
-       char m_com_buff[256];
-       int m_com_buff_count;
-       bool m_paused_flag;
-       bool m_drive_w_pot;
+struct SerialStats
+{
+    int m_chars_received = 0;
+    int m_commands_received = 0;
+    int m_commands_parsed = 0;
+    int m_commands_not_parsed = 0;
+};
+
+class Session
+{
+public:
+    //interface
+    Session(const int POT_PIN, const int *DRV_PIN, bool paused, bool drive_w_pot = false);
+    void init_temp_sense(const int *TEMP_PINS);
+    void check_for_command();
+    bool check_paused();
+    void read_pot();
+    void read_temp();
+    void drive_magnet();
+    void print_report();
+
+private:
+    //private functions
+    bool process_command();
+    int ramp_signal(int sig_in);
+
+    //data members
+    int m_pot_pin;
+    int m_temp_pins[NUM_TEMP_SENSE];
+    float m_temps[NUM_TEMP_SENSE];
+    int m_drv_pins[8];
+    int m_pwms[NUM_MAGNETS];
+    char m_com_buff[256];
+    int m_com_buff_count;
+    bool m_paused_flag;
+    bool m_drive_w_pot;
+    SerialStats m_serial_stats;
 };
 
 #endif

--- a/dyno/microcontroller/Session.ino
+++ b/dyno/microcontroller/Session.ino
@@ -4,108 +4,156 @@
 
 #include "Session.h"
 
-Session::Session(const int POT_PIN, const int *DRV_PINS, bool paused, bool drive_w_pot) {
+Session::Session(const int POT_PIN, const int *DRV_PINS, bool paused, bool drive_w_pot)
+{
   m_pot_pin = POT_PIN;
-  for (int i = 0; i < NUM_MAGNETS; i++) {
+  for (int i = 0; i < NUM_MAGNETS; i++)
+  {
     m_drv_pins[i] = DRV_PINS[i];
     m_pwms[i] = 0;
   }
   memset(m_com_buff, 0, sizeof(m_com_buff));
   m_com_buff_count = 0;
   m_drive_w_pot = drive_w_pot;
-  if (paused) m_paused_flag = 1;
-  else m_paused_flag = 0;
+  if (paused)
+    m_paused_flag = 1;
+  else
+    m_paused_flag = 0;
 }
 
-void Session::init_temp_sense(const int *TEMP_PINS) {
-  for (int i = 0; i < NUM_TEMP_SENSE; i++) {
+void Session::init_temp_sense(const int *TEMP_PINS)
+{
+  for (int i = 0; i < NUM_TEMP_SENSE; i++)
+  {
     m_temp_pins[i] = TEMP_PINS[i];
   }
 }
 
-void Session::process_command() {
-  if (m_com_buff_count == 1) {
+bool Session::process_command()
+{
+  auto command_parsed = false;
+  if (m_com_buff_count == 1)
+  {
     //easy parsing for single char commands
-    if (m_com_buff[0] == 'R') {
+    if (m_com_buff[0] == 'R')
+    {
       //resume
       m_paused_flag = false;
+      command_parsed = true;
     }
-    if (m_com_buff[0] == 'P') {
+    if (m_com_buff[0] == 'P')
+    {
       //pause
       m_paused_flag = true;
+      command_parsed = true;
     }
-  } else { //multi-char commands
+  }
+  else
+  { //multi-char commands
     //extract command prefix
     String command = "";
     int i;
-    for (i = 0; i < m_com_buff_count; i++) {
-      if (m_com_buff[i] != '=') command += m_com_buff[i];
-      else {i++; break;}
+    for (i = 0; i < m_com_buff_count; i++)
+    {
+      if (m_com_buff[i] != '=')
+        command += m_com_buff[i];
+      else
+      {
+        i++;
+        break;
+      }
     }
 
     //handle commands
-    if (command == "MAGNET") {
+    if (command == "MAGNET")
+    {
       //assumed format:
-      //MAGNET=1:240,3:000, 
-      while (i < m_com_buff_count) {
+      //MAGNET=1:240,3:000,
+      while (i < m_com_buff_count)
+      {
         //still more to be parsed
-        String pwm_str = String(m_com_buff[i+2]) + String(m_com_buff[i+3]) + String(m_com_buff[i+4]);
+        String pwm_str = String(m_com_buff[i + 2]) + String(m_com_buff[i + 3]) + String(m_com_buff[i + 4]);
         m_pwms[m_com_buff[i] - '0'] = pwm_str.toInt();
         i += 6;
       }
-    } 
+      command_parsed = true;
+    }
   }
   //command stored in 256 byte buffer => can implement multi-char commands too
+
+  return command_parsed;
 }
 
-void Session::check_for_command() {
+void Session::check_for_command()
+{
   //buffer incoming data until ; indicates end of command
   char incomingByte;
-  while (Serial.available() > 0) {
+  while (Serial.available() > 0)
+  {
     incomingByte = Serial.read();
-    if (incomingByte == ';') {
-      process_command();
+    m_serial_stats.m_chars_received += 1;
+    if (incomingByte == ';')
+    {
+      m_serial_stats.m_commands_received += 1;
+      if (process_command())
+      {
+        m_serial_stats.m_commands_parsed += 1;
+        Serial.write("ack;");
+      }
+      else
+      {
+        m_serial_stats.m_commands_not_parsed += 1;
+      }
       memset(m_com_buff, 0, sizeof(m_com_buff));
       m_com_buff_count = 0;
     }
-    else {
+    else
+    {
       m_com_buff[m_com_buff_count] = incomingByte;
       m_com_buff_count += 1;
     }
   }
 }
 
-bool Session::check_paused() {
+bool Session::check_paused()
+{
   //paused flag is read only, writeable only by LP
   return m_paused_flag;
 }
 
-int Session::ramp_signal(int sig_in) {
+int Session::ramp_signal(int sig_in)
+{
   //currently does not ramp. Probably worth implementing to avoid unrealistic load spikes
-  return (int) map(sig_in, POT_LOWER, POT_UPPER, 0, 255);
+  return (int)map(sig_in, POT_LOWER, POT_UPPER, 0, 255);
 }
 
-void Session::read_pot() {
+void Session::read_pot()
+{
   int pot_sig = analogRead(m_pot_pin);
   if (m_drive_w_pot)
     for (int i = 0; i < NUM_MAGNETS; i++)
       m_pwms[i] = ramp_signal(pot_sig);
 }
 
-void Session::read_temp() {
+void Session::read_temp()
+{
   float voltage;
-  for (int i = 0; i < NUM_TEMP_SENSE; i++) {
+  for (int i = 0; i < NUM_TEMP_SENSE; i++)
+  {
     voltage = analogRead(m_temp_pins[i]) * 5.0 / 1024.0;
     m_temps[i] = (voltage - 0.5) * 100;
   }
 }
 
-void Session::drive_magnet() {
-  for (int i = 0; i < NUM_MAGNETS; i++) {
+void Session::drive_magnet()
+{
+  for (int i = 0; i < NUM_MAGNETS; i++)
+  {
     analogWrite(m_drv_pins[i], m_pwms[i]);
   }
 }
 
-void Session::print_report() {
+void Session::print_report()
+{
   //print a bunch of diagnostic stuff
 }

--- a/dyno/microcontroller/Session.ino
+++ b/dyno/microcontroller/Session.ino
@@ -98,11 +98,12 @@ void Session::check_for_command()
       if (process_command())
       {
         m_serial_stats.m_commands_parsed += 1;
-        Serial.write("ack;");
+        Serial.write("ack=200;");
       }
       else
       {
         m_serial_stats.m_commands_not_parsed += 1;
+        Serial.write("ack=400;");
       }
       memset(m_com_buff, 0, sizeof(m_com_buff));
       m_com_buff_count = 0;


### PR DESCRIPTION
### Summary
Microcontroller now writes `ack;` to `Serial` after the successful parsing of a command. A `SerialStats` struct was also added as the first step towards generating diagnostics from the microcontroller. The next step there is to either serialize that struct and write it like anything else to `Serial`, or to write it to persistent memory on the Teensy.

### Test Plan
- [x] Code compiles
- [ ] Tested on microcontroller

**Note:** There appear to be many lines changed because I recently turned on auto format on save. Sorry if that makes it harder to review, but would definitely recommend doing that too!