### PR TITLE
Added flag to support digital read

### DIFF
--- a/motor_control/throttle/base_throttle.h
+++ b/motor_control/throttle/base_throttle.h
@@ -4,7 +4,7 @@
 class Throttle
 {
 public:
-    Throttle(const int &pin);
+    Throttle(const int &pin, bool digital = false);
 
     virtual void compute_motor_value() = 0; // this needs to be implemented differently for variable/button throttle
 
@@ -16,6 +16,7 @@ private:
     int m_raw_value;
     int m_motor_value;
     int m_sensor_pin;
+    bool m_digital_read;
 };
 
 #endif

--- a/motor_control/throttle/base_throttle.ino
+++ b/motor_control/throttle/base_throttle.ino
@@ -1,16 +1,20 @@
 #include "base_throttle.h"
 
-Throttle::Throttle(const int &pin)
+Throttle::Throttle(const int &pin, bool digital)
 {
     m_sensor_pin = pin;
     pinMode(m_sensor_pin, INPUT);
     m_raw_value = 0;
     m_motor_value = 0;
+    m_digital_read = digital;
 }
 
 void Throttle::read_sensor_value()
 {
-    m_raw_value = analogRead(m_sensor_pin);
+    if (m_digital_read)
+        m_raw_value = digitalRead(m_sensor_pin);
+    else
+        m_raw_value = analogRead(m_sensor_pin);
 }
 
 int Throttle::get_raw_value() const


### PR DESCRIPTION
### Summary
This PR adds support for throttle implementations that use a digital signal, as opposed to an analog signal. The flag defaults to `false`, so that analog implementations do not need to change at all.